### PR TITLE
Add a patch refs pass before running autopatcher

### DIFF
--- a/BepInEx.MonoMod.Loader/RuntimeMonoModder.cs
+++ b/BepInEx.MonoMod.Loader/RuntimeMonoModder.cs
@@ -50,6 +50,9 @@ namespace BepInEx.MonoMod.Loader
 
 			MapDependencies();
 
+			Log("[Main] mm.PatchRefs(); fixup pre-pass");
+			PatchRefs();
+
 			Log("[Main] mm.AutoPatch();");
 			AutoPatch();
 


### PR DESCRIPTION
To quote @0x0ade: "dunno why, but it's required in BepInEx/and I'm assuming it'd resolve compatibility issues with other patchers down the line anyway/the "bug" was probably with cecil itself/or something related to how monomod wasn't supposed to blend in with multiple patchers/and an additional PatchRefs pass before AutoPatch acts as a good workaround right now" (from the RoR2 modding discord)