### PR TITLE
Fix types from assemblies referenced by mods not resolving

### DIFF
--- a/BepInEx.MonoMod.Loader/MonoModLoader.cs
+++ b/BepInEx.MonoMod.Loader/MonoModLoader.cs
@@ -38,13 +38,19 @@ namespace BepInEx.MonoMod.Loader
 				monoModder.DependencyDirs.AddRange(ResolveDirectories);
 
 				var resolver = (BaseAssemblyResolver)monoModder.AssemblyResolver;
+				var moduleResolver = (BaseAssemblyResolver)monoModder.Module.AssemblyResolver;
 
 				foreach (var dir in ResolveDirectories)
 					resolver.AddSearchDirectory(dir);
 
 				resolver.ResolveFailure += ResolverOnResolveFailure;
+				// Add our dependency resolver to the assembly resolver of the module we are patching
+				moduleResolver.ResolveFailure += ResolverOnResolveFailure;
 
 				monoModder.PerformPatches(monoModPath);
+
+				// Then remove our resolver after we are done patching to not interfere with other patchers
+				moduleResolver.ResolveFailure -= ResolverOnResolveFailure;
 			}
 		}
 


### PR DESCRIPTION
`AssemblyReference` is passed to the patcher, which means the `AssemblyResolver` it uses is the default one. The `RuntimeMonoMod` instance then sets its target `Module` to the `MainModule` of that passed `AssemblyReference`. When MonoMod then calls `Module.ImportReference(typeRef)` from `FindTypeDeep` called with a type from a module referenced by the mod, it sets the `TypeReference.Module` to the `ModuleDefinition` with the default assembly resolver, which then fails to resolve that the assembly name reference specified in the `TypeReference.Scope` and the patching fails.